### PR TITLE
fix: remove multiple tssSocket instance

### DIFF
--- a/Sources/tssClientSwift/TSSConnectionInfo.swift
+++ b/Sources/tssClientSwift/TSSConnectionInfo.swift
@@ -60,12 +60,17 @@ internal final class TSSConnectionInfo {
     public func removeAll(session: String) {
         queue.sync(flags: .barrier) {
             endpoints.removeAll(where: { $0.session == session })
-            if let i = socketManagers.firstIndex(where: { $0.session == session }) {
-                if let socketManager = socketManagers[i].socketManager {
-                    socketManager.disconnect()
-                }
-                socketManagers.remove(at: i)
+            let sessionSockets = socketManagers.filter { $0.session == session }
+            
+            for tssSocket in sessionSockets {
+                let manager = tssSocket.socketManager
+                manager?.reconnects = false
+                manager?.defaultSocket.removeAllHandlers()
+                manager?.defaultSocket.disconnect()
+                manager?.disconnect()
             }
+            socketManagers.removeAll(where: { $0.session == session})
+            
             if let i = endpoints.firstIndex(where: { $0.session == session }) {
                 endpoints.remove(at: i)
             }


### PR DESCRIPTION
on removingAll function call,

session's sockets only remove first found socket instead session's all sockets.
This is causing memory leak in ios

This pr disconnect all session's sockets upon removeAll function called.

**Before**

<img width="1463" height="868" alt="Screenshot 2025-10-17 at 3 36 56 PM" src="https://github.com/user-attachments/assets/271c753f-000f-4127-a328-c6f39ed95c38" />

**After**

<img width="1463" height="868" alt="Screenshot 2025-10-17 at 3 35 57 PM" src="https://github.com/user-attachments/assets/abf59e33-c0e7-46f5-8403-ea5dbe75ff83" />
